### PR TITLE
Fix comma in gulpfile.js variable declarations

### DIFF
--- a/generators/app/templates/_gulpfile.js
+++ b/generators/app/templates/_gulpfile.js
@@ -1,4 +1,4 @@
-var	pug 			= require('gulp-pug');
+var	pug 			= require('gulp-pug'),
 	gulp 			= require('gulp'),
 	sass 			= require('gulp-sass'),
 	notify 			= require("gulp-notify"),


### PR DESCRIPTION
The first line of variable declarations ended with a semicolon instead of a comma.